### PR TITLE
ci: fix release-please credentials

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,10 +13,17 @@ jobs:
     name: Release Please
     runs-on: ubuntu-latest
     steps:
+      - name: Get Token
+        id: get_workflow_token
+        uses: peter-murray/workflow-application-token-action@v4
+        with:
+          application_id: ${{ secrets.APPLICATION_ID }}
+          application_private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.get_workflow_token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Summary

- Replaces `secrets.GITHUB_TOKEN` with a GitHub App token obtained via `peter-murray/workflow-application-token-action@v4`
- Root cause: the repo's Actions settings block `GITHUB_TOKEN` from creating pull requests — release-please was failing with _"GitHub Actions is not permitted to create or approve pull requests"_ on every push to `main`
- Matches the same pattern used in `tidiness/tidy-python`

## Before merging

Add these two secrets to the repo (Settings → Secrets and variables → Actions):

| Secret | Value |
|--------|-------|
| `APPLICATION_ID` | Numeric ID of the GitHub App |
| `APPLICATION_PRIVATE_KEY` | PEM private key of the GitHub App |

The GitHub App needs **Contents: write** and **Pull requests: write** permissions on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)