### PR TITLE
fix: check AX movable/resizable before setting window frame

### DIFF
--- a/Sources/McMacWindowCore/WindowMover.swift
+++ b/Sources/McMacWindowCore/WindowMover.swift
@@ -118,22 +118,69 @@ public class WindowMover {
         return size
     }
 
-    public func setFrame(_ rect: CGRect, on window: AXUIElement) {
-        // Set size first, then position, then size again. This order handles
-        // cross-screen moves in both directions: when moving to a smaller screen
-        // the first resize prevents the window server from clamping the position;
-        // the second resize corrects any clamping that happened during the move
-        // to a larger screen. This is the same strategy used by Rectangle.
+    /// Returns true when the window's AX element reports it can be moved.
+    /// Falls back to true when the attribute is absent (assume movable by default).
+    public func isMovable(_ window: AXUIElement) -> Bool {
+        var ref: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(window, "AXMovable" as CFString, &ref) == .success,
+              let val = ref else { return true }
+        return (val as? Bool) ?? true
+    }
+
+    /// Returns true when the window's AX element reports it can be resized.
+    /// Falls back to true when the attribute is absent (assume resizable by default).
+    public func isResizable(_ window: AXUIElement) -> Bool {
+        var ref: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(window, "AXResizable" as CFString, &ref) == .success,
+              let val = ref else { return true }
+        return (val as? Bool) ?? true
+    }
+
+    /// Sets the window frame via AX. Returns false if the window is not movable
+    /// or if the position write fails; the caller can log or surface the failure.
+    ///
+    /// When the window is not resizable (kAXResizableAttribute = false) the size
+    /// writes are skipped and the position write is still attempted — this handles
+    /// apps like Notes whose windows can be moved but not resized via AX.
+    ///
+    /// Set size first, then position, then size again. This order handles
+    /// cross-screen moves in both directions: when moving to a smaller screen
+    /// the first resize prevents the window server from clamping the position;
+    /// the second resize corrects any clamping that happened during the move
+    /// to a larger screen. This is the same strategy used by Rectangle.
+    @discardableResult
+    public func setFrame(_ rect: CGRect, on window: AXUIElement) -> Bool {
+        guard isMovable(window) else {
+            logger.warning("window is not movable (kAXMovableAttribute=false) — setFrame skipped")
+            return false
+        }
+
+        let canResize = isResizable(window)
+        if !canResize {
+            logger.info("window is not resizable (kAXResizableAttribute=false) — skipping size writes")
+        }
+
         var size = rect.size
-        if let sizeVal = AXValueCreate(.cgSize, &size) {
-            AXUIElementSetAttributeValue(window, kAXSizeAttribute as CFString, sizeVal)
+        if canResize, let sizeVal = AXValueCreate(.cgSize, &size) {
+            let err = AXUIElementSetAttributeValue(window, kAXSizeAttribute as CFString, sizeVal)
+            if err != .success {
+                logger.warning("kAXSizeAttribute write failed: AXError \(err.rawValue, privacy: .public)")
+            }
         }
         var origin = rect.origin
         if let posVal = AXValueCreate(.cgPoint, &origin) {
-            AXUIElementSetAttributeValue(window, kAXPositionAttribute as CFString, posVal)
+            let err = AXUIElementSetAttributeValue(window, kAXPositionAttribute as CFString, posVal)
+            if err != .success {
+                logger.warning("kAXPositionAttribute write failed: AXError \(err.rawValue, privacy: .public)")
+                return false
+            }
         }
-        if let sizeVal = AXValueCreate(.cgSize, &size) {
-            AXUIElementSetAttributeValue(window, kAXSizeAttribute as CFString, sizeVal)
+        if canResize, let sizeVal = AXValueCreate(.cgSize, &size) {
+            let err = AXUIElementSetAttributeValue(window, kAXSizeAttribute as CFString, sizeVal)
+            if err != .success {
+                logger.warning("kAXSizeAttribute (2nd pass) write failed: AXError \(err.rawValue, privacy: .public)")
+            }
         }
+        return true
     }
 }

--- a/Tests/McMacWindowTests/WindowMoverTests.swift
+++ b/Tests/McMacWindowTests/WindowMoverTests.swift
@@ -165,6 +165,58 @@ class WindowMoverTests: XCTestCase {
         let lw = window.frame.width
         XCTAssertEqual(fw + cw + lw, visibleFrame.width, accuracy: 3, "thirds sum to full width")
     }
+
+    // MARK: - Non-responsive window tests (issue #69)
+
+    /// A normal resizable window should be reported as movable and resizable.
+    func testIsMovableAndResizableForNormalWindow() throws {
+        _ = try requireAXAndScreen()
+        let window = makeTestWindow(); defer { window.close() }
+        guard let ax = findAXWindow(titled: window.title) else { throw XCTSkip("no AX element") }
+        XCTAssertTrue(WindowMover.shared.isMovable(ax), "standard titled+resizable window should be movable")
+        XCTAssertTrue(WindowMover.shared.isResizable(ax), "standard titled+resizable window should be resizable")
+    }
+
+    /// A window created without .resizable in its styleMask should report isResizable = false.
+    func testIsResizableReturnsFalseForNonResizableWindow() throws {
+        _ = try requireAXAndScreen()
+        let window = makeNonResizableTestWindow(); defer { window.close() }
+        guard let ax = findAXWindow(titled: window.title) else { throw XCTSkip("no AX element") }
+        XCTAssertFalse(WindowMover.shared.isResizable(ax), "window without .resizable should report isResizable=false")
+    }
+
+    /// setFrame should return true when the AX writes succeed.
+    func testSetFrameReturnsTrueForNormalWindow() throws {
+        let visibleFrame = try requireAXAndScreen()
+        let window = makeTestWindow(); defer { window.close() }
+        guard let ax = findAXWindow(titled: window.title) else { throw XCTSkip("no AX element") }
+        let primaryHeight = NSScreen.screens[0].frame.height
+        let axVF = axRect(from: visibleFrame, primaryScreenHeight: primaryHeight)
+        let target = CGRect(origin: CGPoint(x: axVF.minX + 50, y: axVF.minY + 50),
+                            size: CGSize(width: 600, height: 400))
+        let result = WindowMover.shared.setFrame(target, on: ax)
+        XCTAssertTrue(result, "setFrame should return true for a normal movable/resizable window")
+    }
+
+    /// For a non-resizable window, setFrame should still move the window (position write)
+    /// but not attempt to resize it, and should return true (position succeeded).
+    func testNonResizableWindowPositionIsStillUpdated() throws {
+        let visibleFrame = try requireAXAndScreen()
+        let window = makeNonResizableTestWindow(); defer { window.close() }
+        guard let ax = findAXWindow(titled: window.title) else { throw XCTSkip("no AX element") }
+        let originalSize = window.frame.size
+        let primaryHeight = NSScreen.screens[0].frame.height
+        let axVF = axRect(from: visibleFrame, primaryScreenHeight: primaryHeight)
+        let newOrigin = CGPoint(x: axVF.minX + 80, y: axVF.minY + 80)
+        let result = WindowMover.shared.setFrame(
+            CGRect(origin: newOrigin, size: CGSize(width: 800, height: 600)), on: ax)
+        pump()
+        XCTAssertTrue(result, "setFrame should return true even for non-resizable window (position write can still succeed)")
+        XCTAssertEqual(window.frame.origin.x, newOrigin.x, accuracy: 3, "x should be updated")
+        // Size should remain at the original (non-resizable window ignores resize)
+        XCTAssertEqual(window.frame.size.width, originalSize.width, accuracy: 3,
+                       "width should be unchanged for non-resizable window")
+    }
 }
 
 // MARK: - Helpers
@@ -179,6 +231,22 @@ private func makeTestWindow() -> NSWindow {
         backing: .buffered, defer: false
     )
     w.title = "mcmac-test-\(_counter)-\(ProcessInfo.processInfo.processIdentifier)"
+    w.makeKeyAndOrderFront(nil)
+    NSApp.activate(ignoringOtherApps: true)
+    pump(0.15)
+    return w
+}
+
+/// Creates a window without .resizable in its styleMask, simulating apps like Notes
+/// whose windows reject AX size writes (kAXResizableAttribute = false).
+private func makeNonResizableTestWindow() -> NSWindow {
+    _counter += 1
+    let w = NSWindow(
+        contentRect: NSRect(x: 300, y: 300, width: 500, height: 400),
+        styleMask: [.titled, .closable],
+        backing: .buffered, defer: false
+    )
+    w.title = "mcmac-test-noresize-\(_counter)-\(ProcessInfo.processInfo.processIdentifier)"
     w.makeKeyAndOrderFront(nil)
     NSApp.activate(ignoringOtherApps: true)
     pump(0.15)


### PR DESCRIPTION
## Summary

- Adds `isMovable(_:)` and `isResizable(_:)` helpers that read `AXMovable` / `AXResizable` from a window's AX element before attempting any writes
- Makes `setFrame` return `@discardableResult Bool` — returns `false` immediately for non-movable windows; skips size writes but still moves non-resizable windows
- Captures and logs `AXError` from every `AXUIElementSetAttributeValue` call so failures are visible in Console

Closes #69

## Root cause

`setFrame` discarded all `AXError` return values. When an app window rejected AX writes (e.g. Notes in certain states, or any window with `kAXResizableAttribute = false`), the failure was silent — no log, no user feedback.

## Tests added

- `testIsMovableAndResizableForNormalWindow` — standard titled+resizable window reports both attributes as `true`
- `testIsResizableReturnsFalseForNonResizableWindow` — window created without `.resizable` styleMask reports `AXResizable = false`
- `testSetFrameReturnsTrueForNormalWindow` — verifies the new `Bool` return type on success
- `testNonResizableWindowPositionIsStillUpdated` — position is updated even when size writes are skipped; original size is preserved

## Test plan

- [ ] `./test.sh` passes (non-window-server tests pass; window-server tests skip or pass locally)
- [ ] `./build.sh --warnings-as-errors` passes
- [ ] Manually snap Notes window — it moves to the new position even though it can't be resized
- [ ] `log stream --predicate 'subsystem == "org.nathandrew.mcmac-window"' --level debug` shows "not resizable — skipping size writes" for Notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)